### PR TITLE
The module now works even if it is located in vendor directory

### DIFF
--- a/bin/zf2_components_list_generator.php
+++ b/bin/zf2_components_list_generator.php
@@ -1,6 +1,10 @@
 <?php
 
-if(file_exists(__DIR__ . '/../vendor/autoload.php')) {
+if(file_exists(__DIR__ . '/../autoload.php')) {
+    require_once __DIR__ . '/../autoload.php';
+} else if(file_exists(__DIR__ . '/../../../autoload.php')) {
+    require_once __DIR__ . '/../../../autoload.php';
+} else if(file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once __DIR__ . '/../vendor/autoload.php';
 } else if(file_exists(__DIR__ . '/../../../vendor/autoload.php')) {
     require_once __DIR__ . '/../../../vendor/autoload.php';


### PR DESCRIPTION
The `zf2_components_list_generator.php` wasn't working if downloaded with composer because it was assuming the module was located in `module` folder.
I included two more checks of `autoload.php` constructing the path from `vendor` directory.
